### PR TITLE
Update toggle-highlighter.kak

### DIFF
--- a/rc/toggle-highlighter.kak
+++ b/rc/toggle-highlighter.kak
@@ -1,4 +1,6 @@
 provide-module toggle-highlighter %{
+  require-module prelude
+
   # Signature:
   # toggle-highlighter <path>/[name] <type> [type-params…]
   define-command toggle-highlighter -params 2.. -docstring 'toggle-highlighter <path>/[name] <type> [type-params…]' %{
@@ -17,6 +19,8 @@ provide-module toggle-highlighter %{
       # If [name] is empty, it will be auto-generated.
       # https://github.com/mawww/kakoune/blob/master/src/commands.cc
       evaluate-commands %sh{
+        . "$kak_opt_prelude_path"
+        
         auto_name() {
           printf '%s' "$*" | sed '
             s_/_<slash>_g


### PR DESCRIPTION
First of all, thank you for your work, your plugins are a charm to work with :blush: 

Unfortunately, in your last commit you broke `toggle-highlighter.kak`: the prelude .sh script isn't being loaded, which causes it to fail.
Also, one has to manually write another `require-module` in one's `kakrc`. I therefore propose adding that to `toggle-highlighter.kak`:
* Added `require-module prelude` to automatically check that it's loaded.
* Added missing loading of prelude .sh script

Kind regards, Anton